### PR TITLE
Removed the lazy redraw config

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -105,9 +105,6 @@ set hlsearch
 " Makes search act like search in modern browsers
 set incsearch
 
-" Don't redraw while executing macros (good performance config)
-set lazyredraw
-
 " For regular expressions turn magic on
 set magic
 


### PR DESCRIPTION
It was stopping the lightline plugin from rendering when running vim from the terminal
